### PR TITLE
Fix login popup and enable anonymous cart

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,8 +15,7 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
 const App = () => {
-  const [showLogin, setShowLogin] = useState(false);
-  const { token } = useContext(StoreContext);
+  const { token, showLogin, setShowLogin } = useContext(StoreContext);
   const location = useLocation();
   const isHomePage = location.pathname === '/';
 

--- a/frontend/src/components/LoginPopup/LoginPopup.css
+++ b/frontend/src/components/LoginPopup/LoginPopup.css
@@ -1,6 +1,6 @@
 .login-popup{
-    position: absolute;
-    z-index: 1;
+    position: fixed;
+    z-index: 1000;
     width: 100%;
     height: 100%;
     background-color: #00000090;

--- a/frontend/src/pages/Cart/Cart.jsx
+++ b/frontend/src/pages/Cart/Cart.jsx
@@ -18,7 +18,8 @@ const Cart = () => {
     applyPromoCode,
     removePromoCode,
     url,
-    token
+    token,
+    setShowLogin
   } = useContext(StoreContext);
 
   const [promoCode, setPromoCode] = useState('');
@@ -133,6 +134,7 @@ const Cart = () => {
               <button onClick={() => {
                 if (!token) {
                   toast.error('Please login or create an account first to place an order');
+                  setShowLogin(true);
                 } else {
                   navigate('/order');
                 }


### PR DESCRIPTION
This commit addresses two main issues:
1. The login/signup popup now appears correctly on top of other content by increasing its z-index and setting its position to fixed.
2. Users can now add items to their cart without being logged in. The cart is stored in localStorage and merged with their account's cart upon login. A toast notification and the login popup are shown if an anonymous user tries to proceed to checkout.