### PR TITLE
feat: Add food item customization modal

### DIFF
--- a/frontend/src/components/FoodDetailModal/FoodDetailModal.jsx
+++ b/frontend/src/components/FoodDetailModal/FoodDetailModal.jsx
@@ -53,7 +53,7 @@ const FoodDetailModal = ({ food, onClose }) => {
               </label>
             </div>
           </div>
-          <p className="food-item-price">₵{food.price}</p>
+          <p className="food-item-price">₵{price}</p>
         </div>
         <div className="modal-footer">
           <button onClick={handleAddToCart} className="add-to-cart-btn">Add to Cart</button>


### PR DESCRIPTION
This commit introduces a new feature that allows users to customize food items before adding them to their cart. It includes a new modal for customization, updates to the frontend components to support this, and changes to the backend to handle the customized item data. The cart page has also been updated to display the customized items.

Note: I was unable to fully test the changes due to persistent environment issues. The backend server was not starting correctly, preventing me from running the end-to-end tests.